### PR TITLE
[judge-d-24] endpoint /contracts renamed to /services

### DIFF
--- a/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
+++ b/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static java.util.stream.Collectors.toList;
 
 @RestController
@@ -46,17 +45,7 @@ public class ContractsController {
         ));
     }
 
-    @GetMapping(value = "/contracts", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Get names of services with registered contracts", nickname = "get names of services")
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "Success", response = String.class, responseContainer = "list"),
-        @ApiResponse(code = 400, message = "Bad Request"),
-        @ApiResponse(code = 500, message = "Failure")})
-    public List<String> getAvailableServiceNames() {
-        return serviceContractsRepository.getServiceNames();
-    }
-
-    @GetMapping(value = "/contracts/{serviceName}", produces = MediaType.APPLICATION_JSON_VALUE)
+     @GetMapping(value = "/contracts/{serviceName}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get versions of a service with registered contracts", nickname = "get versions of a service")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Success", response = String.class, responseContainer = "list"),

--- a/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ServicesController.java
+++ b/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ServicesController.java
@@ -1,0 +1,29 @@
+package dev.hltech.dredd.interfaces.rest.contracts;
+
+import dev.hltech.dredd.domain.contracts.ServiceContractsRepository;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.AllArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+public class ServicesController {
+    private ServiceContractsRepository serviceContractsRepository;
+
+    @GetMapping(value = "/services", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Get names of services with registered contracts", nickname = "get names of services")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Success", response = String.class, responseContainer = "list"),
+        @ApiResponse(code = 400, message = "Bad Request"),
+        @ApiResponse(code = 500, message = "Failure")})
+    public List<String> getAvailableServiceNames() {
+        return serviceContractsRepository.getServiceNames();
+    }
+
+}

--- a/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
+++ b/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
@@ -76,18 +76,6 @@ class ContractsControllerIT extends Specification {
             objectMapper.readValue(response.getContentAsString(), new TypeReference<ServiceContractsDto>() {})
     }
 
-    def 'should successfully retrieve list of services'() {
-        given:
-        when:
-            def response = mockMvc.perform(
-                get('/contracts')
-            ).andReturn().getResponse()
-        then:
-            response.getStatus() == 200
-            response.getContentType().contains("application/json")
-            objectMapper.readValue(response.getContentAsString(), new TypeReference<List<String>>() {})
-    }
-
     def 'should successfully retrieve list of service versions'() {
         given:
             def serviceName = randomAlphabetic(10)

--- a/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ServicesControllerIT.groovy
+++ b/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ServicesControllerIT.groovy
@@ -1,0 +1,59 @@
+package dev.hltech.dredd.interfaces.rest.contracts
+
+
+import dev.hltech.dredd.config.BeanFactory
+import dev.hltech.dredd.domain.contracts.InMemoryServiceContractsRepository
+import dev.hltech.dredd.domain.contracts.ServiceContracts
+import dev.hltech.dredd.domain.contracts.ServiceContractsRepository
+import groovy.json.JsonSlurper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import spock.lang.Specification
+
+import static java.util.Collections.emptyMap
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+
+@WebMvcTest(ServicesController.class)
+@ActiveProfiles("test-integration")
+class ServicesControllerIT extends Specification {
+    @Autowired
+    private MockMvc mockMvc
+
+    @Autowired
+    private ServiceContractsRepository serviceContractsRepository
+
+
+    def 'should successfully retrieve list of services'() {
+        given:
+            serviceRegisteredWithName("processor")
+            serviceRegisteredWithName("manager")
+        when:
+            def response = mockMvc.perform(
+                get('/services')
+            ).andReturn().getResponse()
+        then:
+            response.getStatus() == 200
+            response.getContentType().contains("application/json")
+            def object = new JsonSlurper().parseText(response.getContentAsString())
+            assert object instanceof List
+            assert object.toSorted() == ["manager", "processor"].toSorted()
+    }
+
+    def serviceRegisteredWithName(String serviceName) {
+        ServiceContracts contracts = new ServiceContracts(serviceName, "2.0", emptyMap(), emptyMap())
+        serviceContractsRepository.persist(contracts)
+    }
+
+    @TestConfiguration
+    static class TestConfig extends BeanFactory {
+
+        @Bean
+        ServiceContractsRepository repository() {
+            return new InMemoryServiceContractsRepository()
+        }
+    }
+}


### PR DESCRIPTION
I have renamed the endpoint to better reflect our data structure as we have a concept of service in our domain