### PR TITLE
[judge-d-24] renamed endpoint /contracts to /contracts/services

### DIFF
--- a/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
+++ b/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
@@ -57,7 +57,7 @@ public class ContractsController {
     }
 
     @GetMapping(value = "/contracts", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ApiOperation(value = "Get contracts registered", nickname = "get names of services")
+    @ApiOperation(value = "Get registered contracts", nickname = "get names of services")
     @ApiResponses(value = {
         @ApiResponse(code = 302, message = "Found")
     })

--- a/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
+++ b/judge-d-server/src/main/java/dev/hltech/dredd/interfaces/rest/contracts/ContractsController.java
@@ -10,10 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.List;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static java.util.stream.Collectors.toList;
 
 @RestController
@@ -46,7 +46,7 @@ public class ContractsController {
         ));
     }
 
-    @GetMapping(value = "/contracts", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/contracts/services", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get names of services with registered contracts", nickname = "get names of services")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Success", response = String.class, responseContainer = "list"),
@@ -55,6 +55,16 @@ public class ContractsController {
     public List<String> getAvailableServiceNames() {
         return serviceContractsRepository.getServiceNames();
     }
+
+    @GetMapping(value = "/contracts", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiOperation(value = "Get contracts registered", nickname = "get names of services")
+    @ApiResponses(value = {
+        @ApiResponse(code = 302, message = "Found")
+    })
+    public RedirectView getServicesEndpointDescription()  {
+        return new RedirectView("contracts/services", true);
+    }
+
 
     @GetMapping(value = "/contracts/{serviceName}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Get versions of a service with registered contracts", nickname = "get versions of a service")

--- a/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
+++ b/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
@@ -88,12 +88,11 @@ class ContractsControllerIT extends Specification {
             objectMapper.readValue(response.getContentAsString(), new TypeReference<List<String>>() {})
     }
 
-    def 'should calling /contracts should redirect to /contracts/services to improve api discovery'() {
-        given:
+    def 'should calling /contracts redirect to /contracts/services to improve api discovery'() {
         when:
-        def response = mockMvc.perform(
-            get('/contracts')
-        ).andReturn().getResponse()
+            def response = mockMvc.perform(
+                get('/contracts')
+            ).andReturn().getResponse()
         then:
             response.getStatus() == 302
             response.getRedirectedUrl() == "contracts/services"

--- a/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
+++ b/judge-d-server/src/test/groovy/dev/hltech/dredd/interfaces/rest/contracts/ContractsControllerIT.groovy
@@ -80,13 +80,25 @@ class ContractsControllerIT extends Specification {
         given:
         when:
             def response = mockMvc.perform(
-                get('/contracts')
+                get('/contracts/services')
             ).andReturn().getResponse()
         then:
             response.getStatus() == 200
             response.getContentType().contains("application/json")
             objectMapper.readValue(response.getContentAsString(), new TypeReference<List<String>>() {})
     }
+
+    def 'should calling /contracts should redirect to /contracts/services to improve api discovery'() {
+        given:
+        when:
+        def response = mockMvc.perform(
+            get('/contracts')
+        ).andReturn().getResponse()
+        then:
+            response.getStatus() == 302
+            response.getRedirectedUrl() == "contracts/services"
+    }
+
 
     def 'should successfully retrieve list of service versions'() {
         given:


### PR DESCRIPTION
In order to increase user experience when working with API I have changed its structure. It is first part of changes towards /contracts/services/{service-name}/versions/{version}