### PR TITLE
Implements #155 enables CORS for capabilities endpoint

### DIFF
--- a/judge-d-server/src/main/java/com/hltech/judged/server/interfaces/rest/contracts/ContractsController.java
+++ b/judge-d-server/src/main/java/com/hltech/judged/server/interfaces/rest/contracts/ContractsController.java
@@ -106,6 +106,7 @@ public class ContractsController {
 
     @GetMapping(value = "services/{serviceName}/versions/{version:.+}/capabilities/{protocol}", produces = MediaType.ALL_VALUE)
     @ApiOperation(value = "Get capabilities of a version of a service for a protocol", nickname = "get capabilities by protocol")
+    @CrossOrigin(origins = "${contracts.cross.origin}")
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Success", response = ServiceContractsDto.class),
         @ApiResponse(code = 400, message = "Bad Request"),

--- a/judge-d-server/src/main/resources/application-dev.properties
+++ b/judge-d-server/src/main/resources/application-dev.properties
@@ -21,8 +21,11 @@ logging.level.root=INFO
 
 # database
 spring.datasource.initialization-mode=always
-spring.datasource.url=jdbc:h2:mem:testdb  
+spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
-spring.h2.console.enabled=false  
+spring.h2.console.enabled=false
 spring.jpa.hibernate.ddl-auto=none
-liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
+spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
+
+#endpoint settings
+contracts.cross.origin=http://localhost

--- a/judge-d-server/src/main/resources/application.properties
+++ b/judge-d-server/src/main/resources/application.properties
@@ -37,3 +37,6 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=none
 spring.liquibase.change-log=classpath:/db/changelog/db.changelog-master.xml
+
+#endpoint settings
+contracts.cross.origin=http://localhost

--- a/judge-d-server/src/test/groovy/com/hltech/judged/server/interfaces/rest/contracts/ContractsControllerIT.groovy
+++ b/judge-d-server/src/test/groovy/com/hltech/judged/server/interfaces/rest/contracts/ContractsControllerIT.groovy
@@ -175,6 +175,17 @@ class ContractsControllerIT extends Specification {
         )
     }
 
+    def 'cors configuration to allow using get capabilities url as input for web applications presenting swagger specs' () {
+        when:
+        def response = mockMvc.perform(options("/contracts/services/{serviceName}/versions/{version}/capabilities/{protocol}", "1", "2", "rest" )
+            .header("Access-Control-Request-Method", "GET")
+            .header("Origin", "http://localhost")
+        ).andReturn().getResponse()
+        then:
+        response.getStatus() == 200
+
+    }
+
     @TestConfiguration
     static class TestConfig extends com.hltech.judged.server.config.BeanFactory {
 


### PR DESCRIPTION
This PR introduces a possibility to configure CORS for endpoint 
GET /services/{serviceName}/versions/{version:.+}/capabilities/{protocol}
Currently it support one origin or *.
